### PR TITLE
fix: Fix so it works in TeamCity

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const path = require("path");
 const defaultLogger = {
     done: stats => {
         // Only run this if on Team City
-        if (process.env && !process.env.TEAMCITY_VERSION) {
+        if (path.dirname.indexOf('BuildAgent') === -1) {
             return;
         }
         const { assetsByChunkName, assets } = stats.toJson();


### PR DESCRIPTION
We wanted to use this package, but realized our TeamCity build agents don't have the environment variable TeamCity_Version anymore so instead we are checking for `BuildAgent` in the path.